### PR TITLE
Handle gzip encoded bodies

### DIFF
--- a/domain/request/response.go
+++ b/domain/request/response.go
@@ -1,8 +1,9 @@
 package request
 
 type Response struct {
-	Error              string `json:"error,omitempty"`
-	Target             string `json:"target,omitempty"`
-	ResponseBody       string `json:"responseBody,omitempty"`
-	ResponseStatusCode int    `json:"responseStatusCode,omitempty"`
+	Error              string              `json:"error,omitempty"`
+	Target             string              `json:"target,omitempty"`
+	ResponseBody       string              `json:"responseBody,omitempty"`
+	ResponseHeader     map[string][]string `json:"header,omitempty"`
+	ResponseStatusCode int                 `json:"responseStatusCode,omitempty"`
 }

--- a/domain/request/response.go
+++ b/domain/request/response.go
@@ -4,6 +4,6 @@ type Response struct {
 	Error              string              `json:"error,omitempty"`
 	Target             string              `json:"target,omitempty"`
 	ResponseBody       string              `json:"responseBody,omitempty"`
-	ResponseHeader     map[string][]string `json:"header,omitempty"`
+	ResponseHeader     map[string][]string `json:"responseHeader,omitempty"`
 	ResponseStatusCode int                 `json:"responseStatusCode,omitempty"`
 }

--- a/infrastructure/http/transport.go
+++ b/infrastructure/http/transport.go
@@ -82,6 +82,7 @@ func (t Transport) SendRequestToTarget(rr request.Request, targetUrl string) req
 	responseBody, err := ioutil.ReadAll(response.Body)
 
 	return request.Response{
+		Target:             finalUrl,
 		ResponseBody:       string(responseBody),
 		ResponseStatusCode: response.StatusCode,
 	}

--- a/infrastructure/http/transport.go
+++ b/infrastructure/http/transport.go
@@ -80,12 +80,22 @@ func (t Transport) SendRequestToTarget(rr request.Request, targetUrl string) req
 	}()
 
 	responseBody, err := ioutil.ReadAll(response.Body)
+	responseHeader := readHeaders(response.Header)
 
 	return request.Response{
 		Target:             finalUrl,
 		ResponseBody:       string(responseBody),
+		ResponseHeader:     responseHeader,
 		ResponseStatusCode: response.StatusCode,
 	}
+}
+
+func readHeaders(header http.Header) map[string][]string {
+	responseHeader := make(map[string][]string)
+	for key, value := range header {
+		responseHeader[key] = value
+	}
+	return responseHeader
 }
 
 func createHttpClient() *http.Client {

--- a/infrastructure/http/transport.go
+++ b/infrastructure/http/transport.go
@@ -60,6 +60,11 @@ func (t Transport) SendRequestToTarget(rr request.Request, targetUrl string) req
 
 	for k, vl := range rr.Header {
 		for _, v := range vl {
+			// If accept encoding is not explicitly set,
+			// the compression will be handled handled automatically by transport
+			if k == "Accept-Encoding" {
+				continue
+			}
 			req.Header.Add(k, v)
 		}
 	}

--- a/infrastructure/httpHandler/trackRequest.go
+++ b/infrastructure/httpHandler/trackRequest.go
@@ -40,8 +40,16 @@ func (rs TrackRequest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeResponse(w, "", fmt.Errorf("root is not server"))
 	} else {
 		response := rs.RequestService.TrackRequest(req)
-
+		addHeaders(w, response.ResponseHeader)
 		w.WriteHeader(response.ResponseStatusCode)
 		_, _ = w.Write([]byte(response.ResponseBody))
+	}
+}
+
+func addHeaders(w http.ResponseWriter, header map[string][]string) {
+	for key, values := range header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
 	}
 }

--- a/resources/dashboard.html
+++ b/resources/dashboard.html
@@ -148,8 +148,8 @@
             <button class="button" style="width: 200px;" onclick="deleteRequest()">Delete Request</button>
         </div>
 
+        {{ with .RequestDetails }}
         <table class="request-details-style">
-            {{ with .RequestDetails }}
                 <tr>
                     <td>Timestamp</td>
                     <td>{{.Timestamp}}</td>
@@ -184,40 +184,46 @@
 
                     </td>
                 </tr>
-
-                {{ if .Response }}
-                <tr>
-                    <td>Returned Response</td>
-                    <td>
-                        <table style = "width: 500px;">
-                            <tr>
-                                <td>Target Host</td>
-                                <td>{{ .Response.Target }}</td>
-                            </tr>
-                            <tr>
-                                <td>StatusCode</td>
-                                <td>{{ .Response.ResponseStatusCode }}</td>
-                            </tr>
-                            <tr>
-                                <td>ResponseBody</td>
-                                <td>{{ .Response.ResponseBody }}</td>
-                            </tr>
-
-                            {{ if .Response.Error }}
-                            <tr>
-                                <td>Error</td>
-                                <td>{{ .Response.Error }}</td>
-                            </tr>
-                            {{ end }}
-                        </table>
-
-                    </td>
-                </tr>
-                {{ end }}
-
-            {{ end }}
         </table>
+        {{ if .Response }}
+        <h2>Returned Response</h2>
+        <table class="request-details-style">
+            <tr>
+                <td>Target Host</td>
+                <td>{{ .Response.Target }}</td>
+            </tr>
+            <tr>
+                <td>StatusCode</td>
+                <td>{{ .Response.ResponseStatusCode }}</td>
+            </tr>
+            <tr>
+                <td>ResponseBody</td>
+                <td>{{ .Response.ResponseBody }}</td>
+            </tr>
 
+            {{ if .Response.Error }}
+            <tr>
+                <td>Error</td>
+                <td>{{ .Response.Error }}</td>
+            </tr>
+            {{ end }}
+
+            <tr>
+                <td>Header</td>
+                <td>
+                    <table style="width: 500px;">
+                        {{ range $key, $value := .Response.ResponseHeader }}
+                        <tr>
+                            <td>{{ $key }}</td>
+                            <td>{{ $value }}</td>
+                        </tr>
+                        {{ end }}
+                    </table>
+                </td>
+            </tr>
+        </table>
+        {{ end }}
+        {{ end }}
     </div>
 
 </div>

--- a/resources/dashboard.html
+++ b/resources/dashboard.html
@@ -197,7 +197,7 @@
                 <td>{{ .Response.ResponseStatusCode }}</td>
             </tr>
             <tr>
-                <td>ResponseBody</td>
+                <td>Body</td>
                 <td>{{ .Response.ResponseBody }}</td>
             </tr>
 


### PR DESCRIPTION
- Ignore the `Accept-Encoding` header to ensure that compression is handled automatically by the go stdlib
- Use the response headers of the proxied request when responding to the original request
- Display reponse headers