### PR TITLE
Enable path variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It is possible to define path variables as regexes. For example, the date in the
 `/api/aggregate/2021-08-15` is a path variable and needs to be passed on to the target host `https://target.host`. 
 Then specify the path as `/api/aggregate/\d{4}-\d{2}-\d{2}` and the target as `https://target.host`. 
 The incoming request URL path will be matched against the `^/api/aggregate/\d{4}-\d{2}-\d{2}$` regex. If it matches,
-the request will be forwarded to `https://target.host/api/aggregate/2021-08-15`.
+the request will be forwarded to `https://target.host/api/aggregate/2021-08-15`. Capture groups and re-ordering is 
+not supported.
 
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Some paths are not available for tracking as they are in use for internal purpos
 * /favicon.ico
 
 # Path variables
-It is possible to define path variables as regexes. For example, the date in the
-`/api/aggregate/2021-08-15` is a variable and needs to be passed on to the target. Then specify the path as
-`/api/aggregate/\d{4}-\d{2}-\d{2}`.
+It is possible to define path variables as regexes. For example, the date in the following path 
+`/api/aggregate/2021-08-15` is a path variable and needs to be passed on to the target host `https://target.host`. 
+Then specify the path as `/api/aggregate/\d{4}-\d{2}-\d{2}` and the target as `https://target.host`. 
+The incoming request URL path will be matched against the `^/api/aggregate/\d{4}-\d{2}-\d{2}$` regex. If it matches,
+the request will be forwarded to `https://target.host/api/aggregate/2021-08-15`.
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Some paths are not available for tracking as they are in use for internal purpos
 * /static/*
 * /favicon.ico
 
-
+# Path variables
+It is possible to define path variables as regexes. For example, the date in the
+`/api/aggregate/2021-08-15` is a variable and needs to be passed on to the target. Then specify the path as
+`/api/aggregate/\d{4}-\d{2}-\d{2}`.
 
 

--- a/application/configService.go
+++ b/application/configService.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"code-fabrik.com/bend/domain/config"
+	"github.com/google/uuid"
 	"sort"
 )
 
@@ -9,7 +10,7 @@ type ConfigService struct {
 	ConfigRepository config.Repository
 }
 
-func (cs ConfigService) GetConfigData(path string) config.ConfigData {
+func (cs ConfigService) GetConfigData(id uuid.UUID) config.ConfigData {
 	configs := cs.ConfigRepository.FindAll()
 	sort.SliceStable(configs, func(i, j int) bool {
 		return configs[i].Path > configs[j].Path
@@ -17,12 +18,12 @@ func (cs ConfigService) GetConfigData(path string) config.ConfigData {
 
 	return config.ConfigData{
 		Configs:       configs,
-		CurrentConfig: cs.getCurrentConfig(path),
+		CurrentConfig: cs.getCurrentConfig(id),
 	}
 }
 
-func (cs ConfigService) getCurrentConfig(path string) config.Config {
-	configData := cs.ConfigRepository.Find(path)
+func (cs ConfigService) getCurrentConfig(id uuid.UUID) config.Config {
+	configData := cs.ConfigRepository.Find(id)
 	if configData != nil {
 		return *configData
 	}
@@ -36,8 +37,8 @@ func (cs ConfigService) getCurrentConfig(path string) config.Config {
 	}
 }
 
-func (cs ConfigService) Delete(path string) error {
-	return cs.ConfigRepository.Delete(path)
+func (cs ConfigService) Delete(id uuid.UUID) error {
+	return cs.ConfigRepository.Delete(id)
 }
 
 func (cs ConfigService) Save(config config.Config) error {

--- a/domain/config/config.go
+++ b/domain/config/config.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
 type Response struct {
 	StatusCode int    `json:"statusCode"`
 	Body       string `json:"body"`
@@ -14,4 +20,23 @@ type Config struct {
 type ConfigData struct {
 	Configs       []Config
 	CurrentConfig Config
+}
+
+func TestIfRegexConfigMatches(configs []Config, path string) (string, error) {
+	for _, config := range configs {
+		matched, _ := regexp.MatchString(`^`+config.Path+`$`, path)
+		if matched && len(config.Target) != 0 {
+			domains := strings.Split(path, `/`)
+			var sb strings.Builder
+			sb.WriteString(config.Target)
+			for _, part := range domains {
+				if len(part) > 0 {
+					sb.WriteString(`/`)
+					sb.WriteString(part)
+				}
+			}
+			return sb.String(), nil
+		}
+	}
+	return "", errors.New("no match")
 }

--- a/domain/config/config.go
+++ b/domain/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"github.com/google/uuid"
 	"regexp"
 	"strings"
 )
@@ -12,9 +13,10 @@ type Response struct {
 }
 
 type Config struct {
-	Path     string   `json:"path"`
-	Target   string   `json:"target"`
-	Response Response `json:"response"`
+	Path     string    `json:"path"`
+	Target   string    `json:"target"`
+	Response Response  `json:"response"`
+	Id       uuid.UUID `json:"id"`
 }
 
 type ConfigData struct {
@@ -22,8 +24,11 @@ type ConfigData struct {
 	CurrentConfig Config
 }
 
-func TestIfRegexConfigMatches(configs []Config, path string) (string, error) {
+func FindFirstMatchingConfig(configs []Config, path string) (Config, error) {
 	for _, config := range configs {
+		if config.Path == path {
+			return config, nil
+		}
 		matched, _ := regexp.MatchString(`^`+config.Path+`$`, path)
 		if matched && len(config.Target) != 0 {
 			domains := strings.Split(path, `/`)
@@ -35,8 +40,9 @@ func TestIfRegexConfigMatches(configs []Config, path string) (string, error) {
 					sb.WriteString(part)
 				}
 			}
-			return sb.String(), nil
+			config.Target = sb.String()
+			return config, nil
 		}
 	}
-	return "", errors.New("no match")
+	return Config{}, errors.New("no match")
 }

--- a/domain/config/config.go
+++ b/domain/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/google/uuid"
 	"regexp"
-	"strings"
 )
 
 type Response struct {
@@ -27,16 +26,7 @@ func (c *Config) GenerateFinalTargetPath(path string) string {
 		return c.Target
 	}
 
-	var sb strings.Builder
-	sb.WriteString(c.Target)
-	domains := strings.Split(path, `/`)
-	for _, part := range domains {
-		if len(part) > 0 {
-			sb.WriteString(`/`)
-			sb.WriteString(part)
-		}
-	}
-	return sb.String()
+	return c.Target + path
 }
 
 type ConfigData struct {

--- a/domain/config/config_test.go
+++ b/domain/config/config_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_GenerateFinalTargetPath(t *testing.T) {
+	config := Config{
+		Path:     "/.*Blub",
+		Target:   "/Bla",
+		Response: Response{},
+		Id:       uuid.UUID{},
+	}
+
+	result := config.GenerateFinalTargetPath("/bliBlub")
+	assert.Equal(t, "/Bla/bliBlub", result)
+}

--- a/domain/config/config_test.go
+++ b/domain/config/config_test.go
@@ -9,11 +9,11 @@ import (
 func Test_GenerateFinalTargetPath(t *testing.T) {
 	config := Config{
 		Path:     "/.*Blub",
-		Target:   "/Bla",
+		Target:   "http://targetUrl",
 		Response: Response{},
 		Id:       uuid.UUID{},
 	}
 
 	result := config.GenerateFinalTargetPath("/bliBlub")
-	assert.Equal(t, "/Bla/bliBlub", result)
+	assert.Equal(t, "http://targetUrl/bliBlub", result)
 }

--- a/domain/config/repository.go
+++ b/domain/config/repository.go
@@ -1,9 +1,11 @@
 package config
 
+import "github.com/google/uuid"
+
 type Repository interface {
 	Save(config Config) error
-	Find(path string) *Config
+	Find(id uuid.UUID) *Config
 	FindAll() []Config
-	Delete(path string) error
+	Delete(id uuid.UUID) error
 	DeleteAll() error
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8
+	github.com/google/uuid v1.3.0
 	github.com/s12v/go-jwks v0.2.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20210309040221-94ec62e08169 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8
-	github.com/gomarkdown/mdtohtml v0.0.0-20180202094705-7346712f31b4 // indirect
 	github.com/s12v/go-jwks v0.2.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20210309040221-94ec62e08169 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8 h1:nWU6p08f1Vg
 github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gordonklaus/ineffassign v0.0.0-20201107091007-3b93a8888063/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
-github.com/Nerzal/gocloak v1.0.0 h1:WllsbIu1dYvdvka1/BbY7khZBJSTjSkGwyDsHHLQmIw=
 github.com/Nerzal/gocloak/v7 v7.11.0 h1:ab2E55lIMCaUfn47uEHiFhvvMHw+yDHL6Pb+GrM+x04=
 github.com/Nerzal/gocloak/v7 v7.11.0/go.mod h1:8fu/dbbIRa1FmLEAOVReZ8PKfbnsl2DwEk6U0giK3KI=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
@@ -14,8 +13,7 @@ github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8 h1:nWU6p08f1VgIalT6iZyqXi4o5cZsz4X6qa87nusfcsc=
 github.com/gomarkdown/markdown v0.0.0-20210208175418-bda154fe17d8/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
-github.com/gomarkdown/mdtohtml v0.0.0-20180202094705-7346712f31b4 h1:Vxxjwxk2/d3kXuyB3DwTHJaNqOGpzOG6pbPrVbwYTCw=
-github.com/gomarkdown/mdtohtml v0.0.0-20180202094705-7346712f31b4/go.mod h1:Ea0UDfSa65IZQd6JaB8JvmA74Bl+VxxVC21CphecRwE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gordonklaus/ineffassign v0.0.0-20201107091007-3b93a8888063/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -54,7 +52,9 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210309040221-94ec62e08169 h1:fpeMGRM6A+XFcw4RPCO8s8hH7ppgrGR22pSIjwM7YUI=
 golang.org/x/sys v0.0.0-20210309040221-94ec62e08169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/infrastructure/httpHandler/configAPI_test.go
+++ b/infrastructure/httpHandler/configAPI_test.go
@@ -33,9 +33,10 @@ func Test_ConfigAPI_DELETE(t *testing.T) {
 	before()
 	putDefaultTestConfig()
 
-	assert.True(t, len(configRepository.FindAll()) == 1)
+	configs := configRepository.FindAll()
+	assert.True(t, len(configs) == 1)
 
-	req, _ := http.NewRequest("DELETE", "/api/configs"+defaultTestConfigInput.Path, nil)
+	req, _ := http.NewRequest("DELETE", "/api/configs/"+configs[0].Id.String(), nil)
 	_, _ = runTestServe(req, configAPI)
 
 	assert.True(t, len(configRepository.FindAll()) == 0)

--- a/infrastructure/httpHandler/configPage.go
+++ b/infrastructure/httpHandler/configPage.go
@@ -5,6 +5,7 @@ import (
 	"code-fabrik.com/bend/infrastructure/htmlTemplate"
 	"code-fabrik.com/bend/infrastructure/jwt/keycloak"
 	"fmt"
+	"github.com/google/uuid"
 	"net/http"
 	"strings"
 )
@@ -15,11 +16,11 @@ type ConfigPage struct {
 }
 
 type ConfigInput struct {
-	OriginalPath string `json:"originalPath"`
-	Path         string `json:"path"`
-	Target       string `json:"target"`
-	StatusCode   string `json:"statusCode"`
-	Body         string `json:"body"`
+	Path       string    `json:"path"`
+	Target     string    `json:"target"`
+	StatusCode string    `json:"statusCode"`
+	Body       string    `json:"body"`
+	Id         uuid.UUID `json:"id"`
 }
 
 func (cp ConfigPage) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -35,11 +36,16 @@ func (cp ConfigPage) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path := strings.TrimPrefix(r.URL.Path, "/configs")
+	id, _ := ParseSubPathAsUUID(r.URL.Path, "/configs/")
 
 	switch r.Method {
 	case http.MethodGet:
-		configData := cp.ConfigService.GetConfigData(path)
+		configData := cp.ConfigService.GetConfigData(id)
 		htmlTemplate.PresentHtmlTemplate(w, "resources/config.html", configData)
 	}
+}
+
+func ParseSubPathAsUUID(path string, prefix string) (uuid.UUID, error) {
+	idAsString := strings.TrimPrefix(path, prefix)
+	return uuid.Parse(idAsString)
 }

--- a/infrastructure/httpHandler/test.go
+++ b/infrastructure/httpHandler/test.go
@@ -48,11 +48,10 @@ var (
 
 var (
 	defaultTestConfigInput = ConfigInput{
-		OriginalPath: "/originalPath",
-		Path:         "/path",
-		Target:       "",
-		StatusCode:   "200",
-		Body:         "testConfigBody",
+		Path:       "/path",
+		Target:     "",
+		StatusCode: "200",
+		Body:       "testConfigBody",
 	}
 
 	defaultTestSendRequestInput = SendRequestInput{

--- a/resources/config.html
+++ b/resources/config.html
@@ -9,21 +9,24 @@
         let API_URL = "/api/configs/";
         let PAGE_URL = "/configs/";
 
-        function openPath(path) {
-            window.location = PAGE_URL + path;
+        function openPath(id) {
+            if (id) {
+                window.location = PAGE_URL + id;
+            } else {
+                window.location = PAGE_URL;
+            }
         }
 
-
-        function deletePath(path) {
+        function deletePath(id) {
             let r = confirm("Delete this configuration?");
             if (r === true) {
-                let sendUrl = API_URL + path;
+                let sendUrl = API_URL + id;
 
                 let xmlHttp = new XMLHttpRequest();
                 xmlHttp.onreadystatechange = function () {
                     if (xmlHttp.readyState === XMLHttpRequest.DONE) {
                         if (xmlHttp.status === 200) {
-                            window.location.reload();
+                            window.location = PAGE_URL;
                         } else {
                             window.alert(xmlHttp.responseText);
                         }
@@ -34,28 +37,30 @@
             }
         }
 
-        function save() {
+        function save(id) {
             let path = document.getElementById("path").value.replace(/^\/+/g, '');
             let statuscode = document.getElementById("statuscode").value;
             let target = document.getElementById("target").value;
             let body = document.getElementById("body").value;
-            let originalPath = "{{ .CurrentConfig.Path }}".replace(/^\/+/g, '');
-            let data = JSON.stringify({ originalPath: originalPath, path: path, statuscode: statuscode, target: target, body: body });
+            let data = JSON.stringify({ path: path, statuscode: statuscode, target: target, body: body, id: id });
 
             let xmlHttp = new XMLHttpRequest();
 
             xmlHttp.onreadystatechange = function () {
                 if (xmlHttp.readyState === XMLHttpRequest.DONE) {
                     if (xmlHttp.status === 200) {
-                        window.location = PAGE_URL + path;
+                        if (/^[0-]*$/.test(id)) {
+                            window.location = PAGE_URL
+                        } else {
+                            window.location = PAGE_URL + id;
+                        }
                     } else {
                         window.alert(xmlHttp.responseText);
                     }
                 }
             }
 
-            let sendUrl = API_URL + path;
-            xmlHttp.open("PUT", sendUrl, true); // true for asynchronous
+            xmlHttp.open("PUT", API_URL, true); // true for asynchronous
             xmlHttp.send(data);
         }
 
@@ -85,16 +90,16 @@
         {{ with .Configs }}
         {{ range . }}
         <tr>
-            <td onclick="openPath({{.Path}})">{{.Path}}</td>
-            <td onclick="deletePath({{.Path}})"><i class="gg-trash"></i></td>
+            <td onclick="openPath({{.Id}})">{{.Path}}</td>
+            <td onclick="deletePath({{.Id}})"><i class="gg-trash"></i></td>
         </tr>
         {{ end }}
         {{ end }}
     </table>
 
     <div class="table-style" style="width: 100%">
+        {{ with .CurrentConfig }}
         <table class="request-details-style">
-            {{ with .CurrentConfig }}
                 <tr>
                     <td>Path</td>
                     <td>
@@ -122,9 +127,9 @@
                         <textarea style="width: 100%; height: 200px;" type="text" id="body">{{.Response.Body}}</textarea>
                     </td>
                 </tr>
-            {{ end }}
         </table>
-        <button class="button" style="width: 200px;" onclick="save()">Save</button>
+        <button class="button" style="width: 200px;" onclick="save({{.Id}})">Save</button>
+        {{ end }}
     </div>
 </div>
 


### PR DESCRIPTION
This feature enables variables in paths, e.g. `/api/aggregate/2021-08-15`. Instead of registering a new configuration for every value, specify a matching regex in the path configuration.  